### PR TITLE
Add JSON-LD support and site settings loading

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,15 +1,11 @@
-TODO:
-Check that OG image works when deployed
-
-TODO:
-Test redirects when deployed
+TODO (When deployed):
+Check that OG image works
+Test redirects
+Test JSONLD
+Test SEO / OG images
 
 TODO:
 Add a basic footer
-
-TODO:
-Create JSONLD component
-https://johndalesandro.com/blog/astro-add-json-ld-structured-data-to-your-website-for-rich-search-results/
 
 TODO:
 Setup robots.txt generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-is": "^19.2.0",
         "sanity": "^5.18.0",
         "sanity-plugin-mux-input": "^2.17.0",
+        "schema-dts": "^2.0.0",
         "styled-components": "^6.3.5",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17"
@@ -16103,6 +16104,27 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-dts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-2.0.0.tgz",
+      "integrity": "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "schema-dts-lib": "^1.0.0"
+      }
+    },
+    "node_modules/schema-dts-lib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz",
+      "integrity": "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      }
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
@@ -17275,7 +17297,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-is": "^19.2.0",
     "sanity": "^5.18.0",
     "sanity-plugin-mux-input": "^2.17.0",
+    "schema-dts": "^2.0.0",
     "styled-components": "^6.3.5",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17"

--- a/scripts/create-component.ts
+++ b/scripts/create-component.ts
@@ -7,6 +7,7 @@ import {
   generateAstroComponent,
   generateComponentSchema,
   generateReactComponent,
+  SCHEMA_ORG_TYPES,
 } from "./utils/file-generators.js";
 import { addComponentToRegistry } from "./utils/registry-updater.js";
 import { addReactComponentToRenderer } from "./utils/render-component-updater.js";
@@ -154,24 +155,49 @@ async function main() {
     });
   }
 
+  // Prompt for JSON-LD structured data
+  const includeJsonLd = await confirm({
+    message:
+      "Include JSON-LD structured data? (Recommended for content-semantic components like FAQs, products, events, team bios — not for layout/visual components like heroes, banners, CTAs)",
+    default: false,
+  });
+
+  let jsonLdSchemaType: string | undefined;
+  if (includeJsonLd) {
+    jsonLdSchemaType = await select({
+      message: "Schema.org type:",
+      choices: SCHEMA_ORG_TYPES.map((t) => ({
+        value: t.value,
+        name: t.name,
+      })),
+    });
+  }
+
   console.log("\nCreating component...");
 
   // Generate files
   const mediaConfig = includeMedia
     ? { allowedTypes: mediaAllowedTypes }
     : undefined;
+  const jsonLdConfig = jsonLdSchemaType
+    ? { schemaType: jsonLdSchemaType }
+    : undefined;
   generateComponentSchema(name, title, fileName, mediaConfig);
 
   if (componentType === "react") {
     // Generate React component and update render-component.astro
-    generateReactComponent(name, fileName, mediaConfig);
+    generateReactComponent(name, fileName, mediaConfig, jsonLdConfig);
     addReactComponentToRenderer(name, fileName);
     console.log(`✓ Created React component: src/components/${fileName}.tsx`);
     console.log("✓ Updated render-component.astro with client:load");
   } else {
     // Generate Astro component
-    generateAstroComponent(name, fileName, mediaConfig);
+    generateAstroComponent(name, fileName, mediaConfig, jsonLdConfig);
     console.log(`✓ Created Astro component: src/components/${fileName}.astro`);
+  }
+
+  if (jsonLdConfig) {
+    console.log(`✓ Added JSON-LD structured data (${jsonLdConfig.schemaType})`);
   }
 
   // Update registry

--- a/scripts/utils/file-generators.ts
+++ b/scripts/utils/file-generators.ts
@@ -6,6 +6,32 @@ type MediaConfig = {
   allowedTypes: "both" | "image" | "video";
 };
 
+type JsonLdConfig = {
+  schemaType: string; // Schema.org type name, e.g. "FAQPage", "Product", or "Thing" for generic
+};
+
+/**
+ * Common Schema.org types for component-level JSON-LD.
+ * Used by the create-component script to offer type selection.
+ */
+export const SCHEMA_ORG_TYPES = [
+  { value: "Article", name: "Article — Blog posts, news articles" },
+  { value: "Event", name: "Event — Concerts, meetups, conferences" },
+  { value: "FAQPage", name: "FAQPage — Frequently asked questions" },
+  { value: "HowTo", name: "HowTo — Step-by-step instructions" },
+  {
+    value: "LocalBusiness",
+    name: "LocalBusiness — Physical business location",
+  },
+  { value: "Organization", name: "Organization — Company, brand, nonprofit" },
+  { value: "Person", name: "Person — Team member, author bio" },
+  { value: "Product", name: "Product — Product card, listing" },
+  { value: "Recipe", name: "Recipe — Cooking recipe" },
+  { value: "Review", name: "Review — Customer review, testimonial" },
+  { value: "VideoObject", name: "VideoObject — Video content" },
+  { value: "Thing", name: "Generic / Custom — Fill in manually" },
+] as const;
+
 /**
  * Generate flexible page type schema file (with component builder)
  */
@@ -213,51 +239,69 @@ export const ${name} = defineType({
 export function generateAstroComponent(
   name: string,
   fileName: string,
-  media?: MediaConfig
+  media?: MediaConfig,
+  jsonLd?: JsonLdConfig
 ): void {
   const pascalName = camelToPascal(name);
+  const schemaType = jsonLd?.schemaType ?? null;
 
-  let content: string;
-
+  // Build imports
+  const imports = [`import type { ${pascalName} } from "sanity.types";`];
   if (media) {
-    content = `---
-import type { ${pascalName} } from "sanity.types";
-import Media from "@/components/media.astro";
-import Heading from "@/components/ui/typography/heading.astro";
-
-/**
- * Props type derived from auto-generated Sanity types
- * _key is optional - present when used in arrays (flexible pages), absent in fixed pages
- */
-type Props = ${pascalName} & { _key?: string };
-
-const { title, media } = Astro.props;
----
-
-<section>
-  <Heading as="h1" size="h1">{title}</Heading>
-  {media && <Media media={media} />}
-</section>
-`;
-  } else {
-    content = `---
-import type { ${pascalName} } from "sanity.types";
-import Heading from "@/components/ui/typography/heading.astro";
-
-/**
- * Props type derived from auto-generated Sanity types
- * _key is optional - present when used in arrays (flexible pages), absent in fixed pages
- */
-type Props = ${pascalName} & { _key?: string };
-
-const { title } = Astro.props;
----
-
-<section>
-  <Heading as="h1" size="h1">{title}</Heading>
-</section>
-`;
+    imports.push(`import Media from "@/components/media.astro";`);
   }
+  imports.push(
+    `import Heading from "@/components/ui/typography/heading.astro";`
+  );
+  if (schemaType) {
+    imports.push(
+      `import type { ${schemaType}, WithContext } from "schema-dts";`
+    );
+    imports.push(`import { serializeJsonLd } from "@/lib/jsonld";`);
+  }
+
+  // Build destructured props
+  const destructuredProps = media ? "title, media" : "title";
+
+  // Build JSON-LD block
+  const jsonLdBlock = schemaType
+    ? `
+/**
+ * JSON-LD structured data for this component.
+ * Maps Sanity fields to Schema.org ${schemaType} properties.
+ * @see https://schema.org/${schemaType}
+ */
+const jsonLdData: WithContext<${schemaType}> = {
+  "@context": "https://schema.org",
+  "@type": "${schemaType}",
+  // TODO: Map your Sanity fields to Schema.org properties
+  name: title ?? "",
+};
+`
+    : "";
+
+  // Build template
+  const mediaTemplate = media ? "\n  {media && <Media media={media} />}" : "";
+  const jsonLdTemplate = schemaType
+    ? `\n  <script type="application/ld+json" set:html={serializeJsonLd(jsonLdData)} />`
+    : "";
+
+  const content = `---
+${imports.join("\n")}
+
+/**
+ * Props type derived from auto-generated Sanity types
+ * _key is optional - present when used in arrays (flexible pages), absent in fixed pages
+ */
+type Props = ${pascalName} & { _key?: string };
+
+const { ${destructuredProps} } = Astro.props;
+${jsonLdBlock}---
+
+<section>
+  <Heading as="h1" size="h1">{title}</Heading>${mediaTemplate}${jsonLdTemplate}
+</section>
+`;
 
   const filePath = join(process.cwd(), "src/components", `${fileName}.astro`);
   writeFileSync(filePath, content, "utf-8");
@@ -269,16 +313,42 @@ const { title } = Astro.props;
 export function generateReactComponent(
   name: string,
   fileName: string,
-  media?: MediaConfig
+  media?: MediaConfig,
+  jsonLd?: JsonLdConfig
 ): void {
   const pascalName = camelToPascal(name);
+  const schemaType = jsonLd?.schemaType ?? null;
 
   const mediaNote = media
     ? "\n// Note: For media rendering in React, create a React-compatible media component\n// that handles the media field data from Sanity.\n"
     : "";
 
+  const jsonLdImport = schemaType
+    ? `import type { ${schemaType}, WithContext } from "schema-dts";\n`
+    : "";
+
+  const jsonLdBlock = schemaType
+    ? `
+  /**
+   * JSON-LD structured data for this component.
+   * Maps Sanity fields to Schema.org ${schemaType} properties.
+   * @see https://schema.org/${schemaType}
+   */
+  const jsonLdData: WithContext<${schemaType}> = {
+    "@context": "https://schema.org",
+    "@type": "${schemaType}",
+    // TODO: Map your Sanity fields to Schema.org properties
+    name: props.title ?? "",
+  };
+`
+    : "";
+
+  const jsonLdTemplate = schemaType
+    ? `\n      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdData) }} />`
+    : "";
+
   const content = `import type { ${pascalName} as ${pascalName}Props } from "sanity.types";
-${mediaNote}
+${jsonLdImport}${mediaNote}
 /**
  * Props type derived from auto-generated Sanity types
  * _key is optional - present when used in arrays (flexible pages), absent in fixed pages
@@ -286,9 +356,9 @@ ${mediaNote}
 type Props = ${pascalName}Props & { _key?: string };
 
 function ${pascalName}(props: Props) {
-  return (
+${jsonLdBlock}  return (
     <section data-key={props._key}>
-      <h1>{props.title}</h1>
+      <h1>{props.title}</h1>${jsonLdTemplate}
     </section>
   );
 }

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -4,9 +4,13 @@ import { Font } from "astro:assets";
 import { ClientRouter, fade } from "astro:transitions";
 import { VisualEditing } from "@sanity/astro/visual-editing";
 import type { SanityDocument } from "@sanity/client";
+import { stegaClean } from "@sanity/client/stega";
+import type { WebSite, WithContext } from "schema-dts";
 import Metadata from "@/components/metadata.astro";
 import Navigation from "@/components/navigation.astro";
+import { serializeJsonLd } from "@/lib/jsonld";
 import { loadNavigation } from "@/sanity/lib/load-navigation";
+import { loadSiteSettings } from "@/sanity/lib/load-site-settings";
 
 type Props = {
   page: SanityDocument;
@@ -21,7 +25,23 @@ const { isPreview } = Astro.locals;
 
 const { title, description, image, imageAlt, noIndex } = Astro.props;
 
-const navigation = await loadNavigation(isPreview);
+const [navigation, siteSettings] = await Promise.all([
+  loadNavigation(isPreview),
+  loadSiteSettings(isPreview),
+]);
+
+const siteUrl = Astro.site ? new URL("/", Astro.site) : new URL("/", Astro.url);
+
+const websiteJsonLd: WithContext<WebSite> = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": `${siteUrl}#website`,
+  name: siteSettings?.title ? stegaClean(siteSettings.title) : "",
+  description: siteSettings?.description
+    ? stegaClean(siteSettings.description)
+    : "",
+  url: siteUrl.toString(),
+};
 ---
 
 <html lang="en">
@@ -38,6 +58,10 @@ const navigation = await loadNavigation(isPreview);
       image={image}
       imageAlt={imageAlt}
       noIndex={noIndex}
+    />
+    <script
+      type="application/ld+json"
+      set:html={serializeJsonLd(websiteJsonLd)}
     />
   </head>
   <body class="bg-background text-foreground text-balance">

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,11 @@
+import type { Thing, WithContext } from "schema-dts";
+
+/**
+ * Safely serializes a JSON-LD object to a string for use in a <script> tag.
+ * Escapes closing script tags to prevent XSS via embedded </script>.
+ */
+export function serializeJsonLd(
+  data: WithContext<Thing> | WithContext<Thing>[]
+): string {
+  return JSON.stringify(data).replace(/<\/script>/gi, "<\\/script>");
+}

--- a/src/sanity/lib/load-site-settings.ts
+++ b/src/sanity/lib/load-site-settings.ts
@@ -1,0 +1,17 @@
+import type { SiteSettings } from "sanity.types";
+import { loadQuery } from "@/sanity/lib/load-query";
+
+const siteSettingsQuery = `
+  *[_type == "siteSettings"][0] {
+    title,
+    description
+  }
+`;
+
+export async function loadSiteSettings(preview?: boolean) {
+  const { data } = await loadQuery<SiteSettings>({
+    query: siteSettingsQuery,
+    preview,
+  });
+  return data;
+}


### PR DESCRIPTION
- Implement JSON-LD structured data generation in component creation scripts.
- Introduce a utility function for serializing JSON-LD data.
- Load site settings from Sanity for dynamic metadata.
- Update layout to include JSON-LD for the website.
- Refactor TODOs for clarity and completeness.
