### PR TITLE
feat: wrap generated components in Container

### DIFF
--- a/scripts/utils/file-generators.ts
+++ b/scripts/utils/file-generators.ts
@@ -270,7 +270,7 @@ export function generateAstroComponent(
   // Build imports
   const imports = [`import type { ${pascalName} } from "sanity.types";`];
   if (media) {
-    imports.push(`import Media from "@/components/media.astro";`);
+    imports.push(`import Media from "@/components/core/media.astro";`);
   }
   imports.push(
     `import Container from "@/components/ui/layout/container.astro";`

--- a/scripts/utils/file-generators.ts
+++ b/scripts/utils/file-generators.ts
@@ -273,6 +273,9 @@ export function generateAstroComponent(
     imports.push(`import Media from "@/components/media.astro";`);
   }
   imports.push(
+    `import Container from "@/components/ui/layout/container.astro";`
+  );
+  imports.push(
     `import Heading from "@/components/ui/typography/heading.astro";`
   );
   if (schemaType) {
@@ -320,9 +323,9 @@ type Props = ${pascalName} & { _key?: string };
 const { ${destructuredProps} } = Astro.props;
 ${jsonLdBlock}---
 
-<section>
+<Container as="section">
   <Heading as="h1" size="h1">{title}</Heading>${mediaTemplate}${jsonLdTemplate}
-</section>
+</Container>
 `;
 
   const filePath = join(process.cwd(), "src/components", `${fileName}.astro`);
@@ -379,9 +382,9 @@ type Props = ${pascalName}Props & { _key?: string };
 
 function ${pascalName}(props: Props) {
 ${jsonLdBlock}  return (
-    <section data-key={props._key}>
+    <div data-key={props._key}>
       <h1>{props.title}</h1>${jsonLdTemplate}
-    </section>
+    </div>
   );
 }
 

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -1,5 +1,6 @@
 ---
 import type { Hero } from "sanity.types";
+import Container from "@/components/ui/layout/container.astro";
 import Heading from "@/components/ui/typography/heading.astro";
 
 /**
@@ -11,6 +12,6 @@ type Props = Hero & { _key?: string };
 const { title } = Astro.props;
 ---
 
-<section>
+<Container as="section">
   <Heading as="h1" size="h1">{title}</Heading>
-</section>
+</Container>

--- a/src/lib/components/render-component.astro
+++ b/src/lib/components/render-component.astro
@@ -1,6 +1,7 @@
 ---
 // React components - imports managed by create:component script
 // [REACT_IMPORTS]
+import Container from "@/components/ui/layout/container.astro";
 import { COMPONENTS, type ComponentName } from "@/registry";
 
 type Props = {
@@ -27,5 +28,11 @@ const loadedModule = componentConfig ? await componentConfig.component() : null;
 const AstroComponent = loadedModule ? (loadedModule as any).default : null;
 ---
 
-{isReact && ReactComp && <ReactComp {...component} client:load />}
+{
+  isReact && ReactComp && (
+    <Container as="section">
+      <ReactComp {...component} client:load />
+    </Container>
+  )
+}
 {!isReact && AstroComponent && <AstroComponent {...component} />}


### PR DESCRIPTION
Closes #20.

## Approach
- **Astro generator** (`scripts/utils/file-generators.ts`): generated `.astro` components now import and wrap their root in `<Container as="section">`.
- **React generator**: generated `.tsx` components render a plain `<div>`. The Container wrapping happens one level up in `src/lib/components/render-component.astro`, which conditionally wraps the React island in `<Container as="section">` before rendering with `client:load`. This is the only place where an Astro component can wrap a React island, since Container is `.astro` and cannot be imported into `.tsx`.
- **Retrofit**: `src/components/hero.astro` now uses `<Container as="section">` for consistency with newly generated components.

## Verification
- `npm run build` passes.

## Notes
- React component output is wrapped by the renderer, so the React component itself stays free of layout concerns (no duplicated Tailwind classes in `.tsx`).
- Existing pre-rendered pages keep working because the Astro renderer wrapping only kicks in for components present in `REACT_COMPONENTS` (currently empty in the boilerplate).