### PR TITLE
fix: scope sitemap to registered page types (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cp .env.example .env
 | `SANITY_API_READ_TOKEN`                | API token with viewer role for visual editing       |
 | `PUBLIC_SANITY_VISUAL_EDITING_ENABLED` | Enable visual editing overlays (`true`/`false`)     |
 | `PUBLIC_SANITY_STUDIO_ROUTE`           | Path where Sanity Studio is served (e.g. `/studio`) |
+| `SITE_URL`                             | Public site URL — used by `robots.txt`, `sitemap-index.xml`, and Open Graph. Must be set as a **build variable** in production (e.g. `https://example.com`). Falls back to `https://localhost:4321` if missing. |
 | `MUX_TOKEN_ID`                         | _(Optional)_ Mux API token ID                       |
 | `MUX_TOKEN_SECRET`                     | _(Optional)_ Mux API token secret                   |
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import { createClient } from "@sanity/client";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, fontProviders } from "astro/config";
 import { loadEnv } from "vite";
+import { getPageTypeNames } from "./src/registry";
 import { sanityApiVersion } from "./src/sanity/constants/sanity-api-version";
 import { sanityTypegen } from "./vite-plugins/sanity-typegen";
 
@@ -54,8 +55,19 @@ async function getSanityPageUrls() {
     useCdn: true,
   });
 
+  // Only include documents whose _type is a registered page type.
+  // Anything else (redirects, leftover/legacy types, etc.) is not a
+  // routable page in [...slug].astro and would 404 if listed here.
+  const pageTypeNames = getPageTypeNames().filter(
+    (name) => name !== "homepage"
+  );
+
+  if (pageTypeNames.length === 0) {
+    return [];
+  }
+
   const pages = await client.fetch(
-    `*[_type != "homepage" && defined(slug.current)]{
+    `*[_type in $pageTypes && defined(slug.current)]{
       "slug": slug.current,
       slugMode,
       "parentPage": parentPage->{
@@ -67,7 +79,8 @@ async function getSanityPageUrls() {
           "parentPage": parentPage->{ "slug": slug.current }
         }
       }
-    }`
+    }`,
+    { pageTypes: pageTypeNames }
   );
 
   const baseUrl = siteUrl.replace(trailingSlashRegex, "");

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -25,7 +25,7 @@ npx sanity dataset create production --visibility public
    - `PUBLIC_SANITY_STUDIO_ROUTE`
    - `PUBLIC_SANITY_VISUAL_EDITING_ENABLED`
    - `SANITY_API_READ_TOKEN`
-   - `SITE_URL`
+   - `SITE_URL` — **must** be the full deployed URL (e.g. `https://example.com`). Read by `astro.config.mjs` at build time and used as Astro's `site`. If missing, `robots.txt` and `sitemap-index.xml` will reference `https://localhost:4321`. After changing it, **trigger a fresh deploy** (a restart won't rebuild).
 8. Deploy.
 
 ## Releasing

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -28,10 +28,22 @@ npx sanity dataset create production --visibility public
    - `SITE_URL` — **must** be the full deployed URL (e.g. `https://example.com`). Read by `astro.config.mjs` at build time and used as Astro's `site`. If missing, `robots.txt` and `sitemap-index.xml` will reference `https://localhost:4321`. After changing it, **trigger a fresh deploy** (a restart won't rebuild).
 8. Deploy.
 
+## Branching workflow
+
+- **Never commit directly to `develop` or `main`.**
+- For every change (feature, fix, chore), create a feature branch off `develop`:
+  ```sh
+  git checkout develop
+  git pull
+  git checkout -b feat/<short-description>   # or fix/, chore/, docs/, etc.
+  ```
+- Push the branch and open a PR into `develop`. Merge the PR (squash or merge commit is fine for feature → develop).
+- `develop` is the integration branch; `main` is production. Only `develop` → `main` release PRs land on `main`.
+
 ## Releasing
 
-- Work on `develop`, run `npm run release` to open the PR to `main`.
-- **Always merge with "Create a merge commit"** — never "Squash and merge". Squashing rewrites SHAs and detaches `develop` from `main`, causing future release PRs to show conflicts.
+- Work on feature branches → merge to `develop` → run `npm run release` to open the release PR from `develop` to `main`.
+- **Always merge the release PR with "Create a merge commit"** — never "Squash and merge". Squashing rewrites SHAs and detaches `develop` from `main`, causing future release PRs to show conflicts.
 
 If a release PR ever shows conflicts:
 


### PR DESCRIPTION
Closes #23.
Related: #22 (SITE_URL docs).

## What

- **Fix:** Sitemap GROQ in \`astro.config.mjs\` was \`*[_type != \"homepage\" && defined(slug.current)]\`, which picked up *every* document with a slug — including types not registered in \`src/registry.ts\`. Those URLs 404'd in production because \`[...slug].astro\` only renders registered page types.
- Now constrained to \`*[_type in \$pageTypes && defined(slug.current)]\` where \`\$pageTypes\` comes from the registry (with \`homepage\` excluded since \`pages/index.astro\` already adds \`/\` via \`@astrojs/sitemap\`).
- Early-returns \`[]\` if no page types are registered (avoids a build error on a fresh boilerplate).

## Docs

- Added \`SITE_URL\` to the env-var reference in README and DEPLOY (was missing — discovered while testing #22; without it, \`robots.txt\` and \`sitemap-index.xml\` reference \`localhost:4321\`).
- Added a **Branching workflow** section to DEPLOY making the feature-branch-off-\`develop\` flow explicit.

## Verification

Local build with production dataset:
\`\`\`sh
SITE_URL=https://jfs-astro-sanity-boilerplate.jacobfri.is \\
PUBLIC_SANITY_DATASET=production \\
npm run build
\`\`\`

\`dist/client/sitemap-0.xml\` — broken URLs gone:

| Before | After |
|---|---|
| \`/\` ✅ | \`/\` ✅ |
| \`/event\` ❌ 404 | — removed |
| \`/fixed\` ❌ 404 | — removed |
| \`/generic-page\` ❌ 404 | — removed |
| \`/not-existing/page-type-one\` ✅ | \`/not-existing/page-type-one\` ✅ |
| \`/page-type-two\` ✅ | \`/page-type-two\` ✅ |
| \`/sub-menu-page-test-redirect\` ✅ | \`/sub-menu-page-test-redirect\` ✅ |

## Follow-up (separate, not in this PR)

\`/sub-menu-page-test-redirect\` is a real page-type doc with a redirect configured against it, so it still appears in the sitemap. Sitemaps usually shouldn't list redirect sources — happy to open a separate issue.